### PR TITLE
Replace monix.Coeval with cats.Eval

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockRequestSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockRequestSpec.scala
@@ -16,6 +16,7 @@ import cats.Eval
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 class RunningHandleHasBlockRequestSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
 
@@ -49,9 +50,9 @@ class RunningHandleHasBlockRequestSpec extends AnyFunSpec with BeforeAndAfterEac
         it("should send back HasBlock message to the sender") {
           // given
           val sender                                  = peerNode("peer", 40400)
-          val blockLookup: BlockHash => Eval[Boolean] = kp(Eval(true))
+          val blockLookup: BlockHash => Eval[Boolean] = kp(Eval.now(true))
           // then
-          NodeRunning.handleHasBlockRequest[Eval](sender, hbr)(blockLookup).apply()
+          NodeRunning.handleHasBlockRequest[Eval](sender, hbr)(blockLookup).value
           // then
           val (peer, msg) = transport.getRequest(0)
           peer should be(sender)
@@ -63,9 +64,9 @@ class RunningHandleHasBlockRequestSpec extends AnyFunSpec with BeforeAndAfterEac
         it("should do nothing") {
           // given
           val sender                                  = peerNode("peer", 40400)
-          val blockLookup: BlockHash => Eval[Boolean] = kp(Eval(false))
+          val blockLookup: BlockHash => Eval[Boolean] = kp(Eval.now(false))
           // then
-          NodeRunning.handleHasBlockRequest[Eval](sender, hbr)(blockLookup).apply()
+          NodeRunning.handleHasBlockRequest[Eval](sender, hbr)(blockLookup).value
           // then
           transport.requests.size should be(0)
         }

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockRequestSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockRequestSpec.scala
@@ -12,7 +12,7 @@ import coop.rchain.p2p.EffectsTestInstances.TransportLayerStub
 import coop.rchain.models.BlockHash.BlockHash
 import com.google.protobuf.ByteString
 import coop.rchain.p2p.EffectsTestInstances
-import monix.eval.Coeval
+import cats.Eval
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -35,8 +35,8 @@ class RunningHandleHasBlockRequestSpec extends AnyFunSpec with BeforeAndAfterEac
 
   private def alwaysSuccess: PeerNode => Protocol => CommErr[Unit] = kp(kp(Right(())))
 
-  implicit private val askConf   = new ConstApplicativeAsk[Coeval, RPConf](conf)
-  implicit private val transport = new TransportLayerStub[Coeval]
+  implicit private val askConf   = new ConstApplicativeAsk[Eval, RPConf](conf)
+  implicit private val transport = new TransportLayerStub[Eval]
 
   override def beforeEach(): Unit = {
     transport.reset()
@@ -48,10 +48,10 @@ class RunningHandleHasBlockRequestSpec extends AnyFunSpec with BeforeAndAfterEac
       describe("if given block is stored") {
         it("should send back HasBlock message to the sender") {
           // given
-          val sender                                    = peerNode("peer", 40400)
-          val blockLookup: BlockHash => Coeval[Boolean] = kp(Coeval(true))
+          val sender                                  = peerNode("peer", 40400)
+          val blockLookup: BlockHash => Eval[Boolean] = kp(Eval(true))
           // then
-          NodeRunning.handleHasBlockRequest[Coeval](sender, hbr)(blockLookup).apply()
+          NodeRunning.handleHasBlockRequest[Eval](sender, hbr)(blockLookup).apply()
           // then
           val (peer, msg) = transport.getRequest(0)
           peer should be(sender)
@@ -62,10 +62,10 @@ class RunningHandleHasBlockRequestSpec extends AnyFunSpec with BeforeAndAfterEac
       describe("if given block is not stored in BlockStore") {
         it("should do nothing") {
           // given
-          val sender                                    = peerNode("peer", 40400)
-          val blockLookup: BlockHash => Coeval[Boolean] = kp(Coeval(false))
+          val sender                                  = peerNode("peer", 40400)
+          val blockLookup: BlockHash => Eval[Boolean] = kp(Eval(false))
           // then
-          NodeRunning.handleHasBlockRequest[Coeval](sender, hbr)(blockLookup).apply()
+          NodeRunning.handleHasBlockRequest[Eval](sender, hbr)(blockLookup).apply()
           // then
           transport.requests.size should be(0)
         }

--- a/models/src/main/scala/coop/rchain/models/EqualsM.scala
+++ b/models/src/main/scala/coop/rchain/models/EqualsM.scala
@@ -8,7 +8,7 @@ import coop.rchain.casper.protocol._
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.crypto.signatures.Signed
-import monix.eval.Coeval
+import cats.Eval
 
 import scala.Function.tupled
 import scala.collection.immutable.BitSet
@@ -100,7 +100,7 @@ object EqualM extends EqualMDerivation {
 
   }
 
-  implicit def coevalEqual[A: EqualM]: EqualM[Coeval[A]] = by(_.value)
+  implicit def EvalEqual[A: EqualM]: EqualM[Eval[A]] = by(_.value)
 
   implicit val ParEqual: EqualM[Par] = gen[Par]
   implicit val ExprEqual             = gen[Expr]

--- a/models/src/main/scala/coop/rchain/models/Memo.scala
+++ b/models/src/main/scala/coop/rchain/models/Memo.scala
@@ -1,27 +1,26 @@
 package coop.rchain.models
 import com.typesafe.scalalogging.Logger
-import monix.eval.Coeval
-import monix.eval.Coeval.Eager
+import cats.{Eval, Now}
 
 @SuppressWarnings(Array("org.wartremover.warts.Var"))
-class Memo[A](f: => Coeval[A]) {
+class Memo[A](f: => Eval[A]) {
 
-  private[this] var thunk             = f
-  private[this] var result: Coeval[A] = _
+  private[this] var thunk           = f
+  private[this] var result: Eval[A] = _
 
-  def get: Coeval[A] = synchronized {
+  def get: Eval[A] = synchronized {
     result match {
-      case e: Eager[A] => e
+      case e: Now[A] => e
       case _ =>
-        Coeval.defer {
+        Eval.defer {
           synchronized {
             result match {
-              case e: Eager[A] => e
+              case e: Now[A] => e
               case _ if thunk != null =>
                 thunk.map { r =>
                   synchronized {
                     thunk = null //allow GC-ing the thunk
-                    result = Coeval.now(r)
+                    result = Eval.now(r)
                     r
                   }
                 }

--- a/models/src/main/scala/coop/rchain/models/ParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/ParMap.scala
@@ -2,7 +2,7 @@ package coop.rchain.models
 
 import java.util.Objects
 
-import monix.eval.Coeval
+import cats.Eval
 
 import scala.collection.immutable.BitSet
 import coop.rchain.models.rholang.implicits._
@@ -10,7 +10,7 @@ import coop.rchain.models.rholang.implicits._
 final case class ParMap(
     ps: SortedParMap,
     connectiveUsed: Boolean,
-    locallyFree: Coeval[BitSet],
+    locallyFree: Eval[BitSet],
     remainder: Option[Var]
 ) {
 
@@ -27,7 +27,7 @@ object ParMap {
   def apply(
       seq: Seq[(Par, Par)],
       connectiveUsed: Boolean,
-      locallyFree: Coeval[BitSet],
+      locallyFree: Eval[BitSet],
       remainder: Option[Var]
   ) =
     new ParMap(SortedParMap(seq), connectiveUsed, locallyFree.memoize, remainder)

--- a/models/src/main/scala/coop/rchain/models/ParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/ParMap.scala
@@ -38,7 +38,7 @@ object ParMap {
       locallyFree: BitSet,
       remainder: Option[Var]
   ): ParMap =
-    apply(seq, connectiveUsed, Coeval.pure(locallyFree), remainder)
+    apply(seq, connectiveUsed, Eval.now(locallyFree), remainder)
 
   def apply(seq: Seq[(Par, Par)]): ParMap =
     apply(seq, connectiveUsed(seq), updateLocallyFree(seq), None)

--- a/models/src/main/scala/coop/rchain/models/ParSet.scala
+++ b/models/src/main/scala/coop/rchain/models/ParSet.scala
@@ -2,15 +2,15 @@ package coop.rchain.models
 
 import java.util.Objects
 
-import monix.eval.Coeval
+import cats.Eval
 
 import scala.collection.immutable.BitSet
 
-//locallyFree is of type Coeval to make use of memoization
+//locallyFree is of type Eval to make use of memoization
 final case class ParSet(
     ps: SortedParHashSet,
     connectiveUsed: Boolean,
-    locallyFree: Coeval[BitSet],
+    locallyFree: Eval[BitSet],
     remainder: Option[Var]
 ) {
 
@@ -29,7 +29,7 @@ object ParSet {
   def apply(
       ps: Seq[Par],
       connectiveUsed: Boolean,
-      locallyFree: Coeval[BitSet],
+      locallyFree: Eval[BitSet],
       remainder: Option[Var]
   ): ParSet =
     ParSet(SortedParHashSet(ps), connectiveUsed, locallyFree.memoize, remainder)
@@ -42,7 +42,7 @@ object ParSet {
     ParSet(
       shs,
       connectiveUsed(ps) || remainder.isDefined,
-      Coeval.delay(updateLocallyFree(shs)).memoize,
+      Eval.now(updateLocallyFree(shs)).memoize,
       remainder
     )
   }

--- a/models/src/main/scala/coop/rchain/models/ParSetTypeMapper.scala
+++ b/models/src/main/scala/coop/rchain/models/ParSetTypeMapper.scala
@@ -1,7 +1,7 @@
 package coop.rchain.models
 
 import scalapb.TypeMapper
-import monix.eval.Coeval
+import cats.Eval
 
 object ParSetTypeMapper {
   implicit val parSetESetTypeMapper: TypeMapper[ESet, ParSet] =

--- a/models/src/main/scala/coop/rchain/models/ParSetTypeMapper.scala
+++ b/models/src/main/scala/coop/rchain/models/ParSetTypeMapper.scala
@@ -10,7 +10,7 @@ object ParSetTypeMapper {
   private[models] def esetToParSet(eset: ESet): ParSet =
     ParSet(
       ps = eset.ps,
-      locallyFree = Coeval.delay(eset.locallyFree.get),
+      locallyFree = Eval.later(eset.locallyFree.get()),
       connectiveUsed = eset.connectiveUsed,
       remainder = eset.remainder
     )

--- a/models/src/main/scala/coop/rchain/models/Pretty.scala
+++ b/models/src/main/scala/coop/rchain/models/Pretty.scala
@@ -3,7 +3,7 @@ import java.io.{PrintWriter, StringWriter}
 
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.hash.Blake2b512Random
-import monix.eval.Coeval
+import cats.Eval
 
 import scala.annotation.switch
 import scala.collection.immutable.{BitSet, HashSet}
@@ -86,9 +86,9 @@ trait PrettyInstances extends PrettyDerivation {
   implicit def prettyAlwaysEqual[A: Pretty]: Pretty[AlwaysEqual[A]] =
     fromWrapped(_.item, value => s"AlwaysEqual($value)")
 
-  implicit def prettyCoeval[A: Pretty]: Pretty[Coeval[A]] =
-    (value: Coeval[A], indentLevel: Int) =>
-      s"Coeval.now(${Pretty[A].pretty(value.value, indentLevel)}) /* was Coeval.${value.getClass.getSimpleName} */"
+  implicit def prettyEval[A: Pretty]: Pretty[Eval[A]] =
+    (value: Eval[A], indentLevel: Int) =>
+      s"Eval.now(${Pretty[A].pretty(value.value, indentLevel)}) /* was Eval.${value.getClass.getSimpleName} */"
 
   implicit val PrettyPar: Pretty[Par]   = gen[Par]
   implicit val PrettyExpr               = gen[Expr]

--- a/models/src/main/scala/coop/rchain/models/ProtoM.scala
+++ b/models/src/main/scala/coop/rchain/models/ProtoM.scala
@@ -9,6 +9,7 @@ import com.google.protobuf.{ByteString, CodedOutputStream, Descriptors, MessageL
 import cats.Eval
 import scalapb.WireType
 import scalapb.compiler.Types
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.collection.JavaConverters._
 

--- a/models/src/main/scala/coop/rchain/models/ProtoM.scala
+++ b/models/src/main/scala/coop/rchain/models/ProtoM.scala
@@ -6,7 +6,7 @@ import cats.syntax.all._
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.WireFormat.FieldType
 import com.google.protobuf.{ByteString, CodedOutputStream, Descriptors, MessageLite}
-import monix.eval.Coeval
+import cats.Eval
 import scalapb.WireType
 import scalapb.compiler.Types
 
@@ -14,19 +14,19 @@ import scala.collection.JavaConverters._
 
 object ProtoM {
 
-  def toByteArray(message: StacksafeMessage[_]): Coeval[Array[Byte]] =
+  def toByteArray(message: StacksafeMessage[_]): Eval[Array[Byte]] =
     for {
       size  <- message.serializedSizeM.get
       array = new Array[Byte](size)
       out   = CodedOutputStream.newInstance(array)
       _     <- ProtoM.writeTo(out, message)
-      _     <- Sync[Coeval].catchNonFatal { out.checkNoSpaceLeft() }
+      _     <- Sync[Eval].catchNonFatal { out.checkNoSpaceLeft() }
     } yield array
 
   def writeTo(
       out: CodedOutputStream,
       message: StacksafeMessage[_]
-  ): Coeval[Unit] = {
+  ): Eval[Unit] = {
     val companion       = message.companion
     val descriptor      = companion.javaDescriptor
     val defaultInstance = companion.defaultInstance.asInstanceOf[StacksafeMessage[_]]
@@ -38,7 +38,7 @@ object ProtoM {
               val default    = defaultInstance.getFieldByNumber(f.getNumber)
               if (fieldValue != default)
                 writeField(out, fieldValue, f)
-              else ().pure[Coeval]
+              else ().pure[Eval]
             })
     } yield ()
   }
@@ -47,7 +47,7 @@ object ProtoM {
       out: CodedOutputStream,
       value: Any,
       field: FieldDescriptor
-  ): Coeval[Unit] =
+  ): Eval[Unit] =
     if (field.isRepeated) {
       writeRepeatedField(out, value, field)
     } else {
@@ -58,9 +58,9 @@ object ProtoM {
       out: CodedOutputStream,
       value: Any,
       field: FieldDescriptor
-  ): Coeval[Unit] =
+  ): Eval[Unit] =
     for {
-      _         <- raiseUnsupportedIf[Coeval](field.isPacked, "Packed fields are unsupported")
+      _         <- raiseUnsupportedIf[Eval](field.isPacked, "Packed fields are unsupported")
       container = value.asInstanceOf[Seq[Any]].toList
       _         <- container.traverse(writeSingleField(out, _, field))
     } yield ()
@@ -69,7 +69,7 @@ object ProtoM {
       out: CodedOutputStream,
       value: Any,
       field: Descriptors.FieldDescriptor
-  ): Coeval[Unit] =
+  ): Eval[Unit] =
     if (field.getLiteType == FieldType.MESSAGE) {
       for {
         _         <- writeTag(out, field, WireType.WIRETYPE_LENGTH_DELIMITED)
@@ -78,7 +78,7 @@ object ProtoM {
         _         <- writeTo(out, value.asInstanceOf[StacksafeMessage[_]])
       } yield ()
     } else if (field.getLiteType == FieldType.ENUM)
-      Sync[Coeval].raiseError(
+      Sync[Eval].raiseError(
         new UnsupportedOperationException(
           s"Enums are not supported, got $value of type ${value.getClass}"
         )
@@ -91,19 +91,19 @@ object ProtoM {
       out: CodedOutputStream,
       field: FieldDescriptor,
       wireType: Int
-  ): Coeval[Unit] =
-    Sync[Coeval].delay { out.writeTag(field.getNumber, wireType) }
+  ): Eval[Unit] =
+    Sync[Eval].delay { out.writeTag(field.getNumber, wireType) }
 
-  private def writeUInt32NoTag(out: CodedOutputStream, valueSize: Int): Coeval[Unit] =
-    Sync[Coeval].delay { out.writeUInt32NoTag(valueSize) }
+  private def writeUInt32NoTag(out: CodedOutputStream, valueSize: Int): Eval[Unit] =
+    Sync[Eval].delay { out.writeUInt32NoTag(valueSize) }
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   private def writeScalarValue(
       value: Any,
       field: FieldDescriptor,
       out: CodedOutputStream
-  ): Coeval[Unit] =
-    Sync[Coeval].catchNonFatal {
+  ): Eval[Unit] =
+    Sync[Eval].catchNonFatal {
 
       import FieldDescriptor.Type._
 
@@ -137,7 +137,7 @@ object ProtoM {
 
   def serializedSize(
       message: StacksafeMessage[_]
-  ): Coeval[Int] = Coeval.defer {
+  ): Eval[Int] = Eval.defer {
     val companion       = message.companion
     val descriptor      = companion.javaDescriptor
     val defaultInstance = companion.defaultInstance.asInstanceOf[StacksafeMessage[_]]
@@ -147,34 +147,34 @@ object ProtoM {
                      val default    = defaultInstance.getFieldByNumber(f.getNumber)
                      if (fieldValue != default)
                        fieldSize(fieldValue, f)
-                     else 0.pure[Coeval]
+                     else 0.pure[Eval]
                    })
     } yield fieldSizes.sum
   }
 
-  private def fieldSize(value: Any, field: Descriptors.FieldDescriptor): Coeval[Int] =
+  private def fieldSize(value: Any, field: Descriptors.FieldDescriptor): Eval[Int] =
     if (field.isRepeated) {
       repeatedSize(value, field)
     } else {
       singleFieldSize(value, field)
     }
 
-  private def repeatedSize(value: Any, field: Descriptors.FieldDescriptor): Coeval[Int] =
+  private def repeatedSize(value: Any, field: Descriptors.FieldDescriptor): Eval[Int] =
     for {
-      _ <- raiseUnsupportedIf[Coeval](field.isPacked, "Packed fields are unsupported")
+      _ <- raiseUnsupportedIf[Eval](field.isPacked, "Packed fields are unsupported")
 
       container = value.asInstanceOf[Seq[Any]].toList
       containerSize <- Types.fixedSize(field.getType) match {
                         case Some(size) =>
                           val tagSize = CodedOutputStream.computeTagSize(field.getNumber)
-                          ((size + tagSize) * container.size).pure[Coeval]
+                          ((size + tagSize) * container.size).pure[Eval]
                         case None =>
                           val elementSizes = container.traverse(singleFieldSize(_, field))
                           elementSizes.map(_.sum)
                       }
     } yield containerSize
 
-  private def singleFieldSize(value: Any, field: Descriptors.FieldDescriptor): Coeval[Int] =
+  private def singleFieldSize(value: Any, field: Descriptors.FieldDescriptor): Eval[Int] =
     if (field.getLiteType == FieldType.MESSAGE) {
       for {
         valueSize     <- value.asInstanceOf[StacksafeMessage[_]].serializedSizeM.get
@@ -182,7 +182,7 @@ object ProtoM {
         tagSize       = CodedOutputStream.computeTagSize(field.getNumber)
       } yield tagSize + valueSizeSize + valueSize
     } else if (field.getLiteType == FieldType.ENUM)
-      Sync[Coeval].raiseError(
+      Sync[Eval].raiseError(
         new UnsupportedOperationException(
           s"Enums are not supported, got $value of type ${value.getClass}"
         )
@@ -192,8 +192,8 @@ object ProtoM {
     }
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-  private def scalarValueSize(value: Any, field: FieldDescriptor): Coeval[Int] =
-    Sync[Coeval].catchNonFatal {
+  private def scalarValueSize(value: Any, field: FieldDescriptor): Eval[Int] =
+    Sync[Eval].catchNonFatal {
 
       import FieldDescriptor.Type._
       import com.google.protobuf.CodedOutputStream._

--- a/models/src/main/scala/coop/rchain/models/SortedParHashSet.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParHashSet.scala
@@ -6,6 +6,7 @@ import cats.Eval
 
 import scala.collection.GenSet
 import scala.collection.immutable.HashSet
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 //Enforce ordering and uniqueness.
 // - uniqueness is handled by using HashSet.

--- a/models/src/main/scala/coop/rchain/models/SortedParHashSet.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParHashSet.scala
@@ -2,7 +2,7 @@ package coop.rchain.models
 
 import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.models.rholang.sorter.ordering._
-import monix.eval.Coeval
+import cats.Eval
 
 import scala.collection.GenSet
 import scala.collection.immutable.HashSet
@@ -34,7 +34,7 @@ final class SortedParHashSet(ps: HashSet[Par]) extends Iterable[Par] {
 
   override def hashCode(): Int = sortedPars.hashCode()
 
-  private def sort(par: Par): Par = Sortable[Par].sortMatch[Coeval](par).map(_.term).value()
+  private def sort(par: Par): Par = Sortable[Par].sortMatch[Eval](par).map(_.term).value
 }
 
 object SortedParHashSet {

--- a/models/src/main/scala/coop/rchain/models/SortedParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParMap.scala
@@ -3,6 +3,7 @@ package coop.rchain.models
 import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.models.rholang.sorter.ordering._
 import cats.Eval
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.collection.GenTraversableOnce
 import scala.collection.immutable.HashMap

--- a/models/src/main/scala/coop/rchain/models/SortedParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParMap.scala
@@ -2,7 +2,7 @@ package coop.rchain.models
 
 import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.models.rholang.sorter.ordering._
-import monix.eval.Coeval
+import cats.Eval
 
 import scala.collection.GenTraversableOnce
 import scala.collection.immutable.HashMap
@@ -47,7 +47,7 @@ final class SortedParMap private (ps: Map[Par, Par]) extends Iterable[(Par, Par)
 
   override def hashCode(): Int = sortedList.hashCode()
 
-  private def sort(par: Par): Par = Sortable[Par].sortMatch[Coeval](par).map(_.term).value()
+  private def sort(par: Par): Par = Sortable[Par].sortMatch[Eval](par).map(_.term).value
 }
 
 object SortedParMap {

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
@@ -5,13 +5,13 @@ import coop.rchain.models.Par
 import coop.rchain.models.rholang.sorter.ScoredTerm._
 import cats.Eval
 import cats.implicits._
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 //FIXME the `.sort` methods in this file should return via F[_] : Sync, and the corresponding ParSet and ParMap should
 //be constructed via factory methods also returning via F. Otherwise we risk StackOverflowErrors.
 object ordering {
 
   implicit class ListSortOps(ps: List[Par]) {
-    implicit val sync = implicitly[Sync[Coeval]]
 
     def sort: List[Par] = {
       val psSorted: List[Eval[ScoredTerm[Par]]] =

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
@@ -1,9 +1,9 @@
 package coop.rchain.models.rholang.sorter
 
-import cats.effect.Sync
+import cats.effect.{ExitCase, Sync}
 import coop.rchain.models.Par
 import coop.rchain.models.rholang.sorter.ScoredTerm._
-import monix.eval.Coeval
+import cats.Eval
 import cats.implicits._
 
 //FIXME the `.sort` methods in this file should return via F[_] : Sync, and the corresponding ParSet and ParMap should
@@ -14,20 +14,19 @@ object ordering {
     implicit val sync = implicitly[Sync[Coeval]]
 
     def sort: List[Par] = {
-      val psSorted: List[Coeval[ScoredTerm[Par]]] =
-        ps.map(par => Sortable[Par].sortMatch[Coeval](par))
-      val coeval: Coeval[List[Par]] = for {
+      val psSorted: List[Eval[ScoredTerm[Par]]] =
+        ps.map(par => Sortable[Par].sortMatch[Eval](par))
+      val eval: Eval[List[Par]] = for {
         parsSorted <- psSorted.sequence
       } yield parsSorted.sorted.map(_.term)
 
-      coeval.value
+      eval.value
     }
   }
 
   implicit class MapSortOps(ps: Map[Par, Par]) {
-    implicit val sync = implicitly[Sync[Coeval]]
 
-    def sortKeyValuePair(key: Par, value: Par): Coeval[ScoredTerm[(Par, Par)]] =
+    def sortKeyValuePair(key: Par, value: Par): Eval[ScoredTerm[(Par, Par)]] =
       for {
         sortedKey   <- Sortable.sortMatch(key)
         sortedValue <- Sortable.sortMatch(value)
@@ -35,10 +34,10 @@ object ordering {
 
     def sort: List[(Par, Par)] = {
       val pairsSorted = ps.toList.map(kv => sortKeyValuePair(kv._1, kv._2))
-      val coeval: Coeval[List[(Par, Par)]] = for {
+      val eval: Eval[List[(Par, Par)]] = for {
         sequenced <- pairsSorted.sequence
       } yield sequenced.sorted.map(_.term)
-      coeval.value
+      eval.value
     }
   }
 

--- a/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
@@ -18,7 +18,8 @@ object implicits {
       override def decode(bytes: ByteVector): Either[Throwable, T] = {
         val companion = implicitly[GeneratedMessageCompanion[T]]
         val buffer    = CodedInputStream.newInstance(bytes.toArray)
-        companion.defaultInstance.mergeFromM[Coeval](buffer).runAttempt()
+        try Right(companion.defaultInstance.mergeFromM[Eval](buffer).value)
+        catch { case e: Throwable => Left(e) }
       }
     }
 

--- a/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
@@ -3,7 +3,7 @@ package coop.rchain.models.serialization
 import com.google.protobuf.CodedInputStream
 import coop.rchain.models._
 import coop.rchain.shared.Serialize
-import monix.eval.Coeval
+import cats.Eval
 import scalapb.GeneratedMessageCompanion
 import scodec.bits.ByteVector
 
@@ -13,7 +13,7 @@ object implicits {
     new Serialize[T] {
 
       override def encode(a: T): ByteVector =
-        ByteVector.view(ProtoM.toByteArray(a).value())
+        ByteVector.view(ProtoM.toByteArray(a).value)
 
       override def decode(bytes: ByteVector): Either[Throwable, T] = {
         val companion = implicitly[GeneratedMessageCompanion[T]]

--- a/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
@@ -6,6 +6,7 @@ import coop.rchain.shared.Serialize
 import cats.Eval
 import scalapb.GeneratedMessageCompanion
 import scodec.bits.ByteVector
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 object implicits {
 

--- a/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
@@ -4,7 +4,7 @@ import com.google.protobuf.ByteString
 import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models.testImplicits._
 import coop.rchain.models.testUtils.TestUtils.forAllSimilarA
-import monix.eval.Coeval
+import cats.Eval
 import org.scalacheck.{Arbitrary, Shrink}
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
@@ -97,7 +97,7 @@ class EqualMSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers
 
     val referenceResult = reference(x, y)
     val equalsResult    = x == y
-    val equalMResult    = EqualM[A].equal[Coeval](x, y).value
+    val equalMResult    = EqualM[A].equal[Eval](x, y).value
 
     withClue(
       s"""

--- a/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
@@ -10,6 +10,7 @@ import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.Function.tupled
 import scala.collection.immutable.BitSet

--- a/models/src/test/scala/coop/rchain/models/HashMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/HashMSpec.scala
@@ -11,6 +11,7 @@ import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.collection.immutable.BitSet
 import scala.reflect.ClassTag

--- a/models/src/test/scala/coop/rchain/models/HashMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/HashMSpec.scala
@@ -5,7 +5,7 @@ import java.util.Objects
 import com.google.protobuf.ByteString
 import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models.testImplicits._
-import monix.eval.Coeval
+import cats.Eval
 import org.scalacheck.Arbitrary
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
@@ -95,7 +95,7 @@ class HashMSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers 
     // This makes this test valid both before and after we override the generated hashCode
     // (which is long done when you're reading this).
     reference should be(a.hashCode())
-    val result = HashM[A].hash[Coeval](a).value
+    val result = HashM[A].hash[Eval](a).value
     result should be(reference)
   }
 }

--- a/models/src/test/scala/coop/rchain/models/MemoSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/MemoSpec.scala
@@ -1,5 +1,5 @@
 package coop.rchain.models
-import monix.eval.Coeval
+import cats.Eval
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -9,7 +9,7 @@ class MemoSpec extends AnyFlatSpec with Matchers {
 
   it should "memoize the result" in {
     var timesExecuted = 0
-    val random = new Memo[Int](Coeval.delay {
+    val random = new Memo[Int](Eval.delay {
       timesExecuted += 1
       9
     })

--- a/models/src/test/scala/coop/rchain/models/MemoSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/MemoSpec.scala
@@ -1,7 +1,9 @@
 package coop.rchain.models
 import cats.Eval
+import cats.effect.Sync
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 class MemoSpec extends AnyFlatSpec with Matchers {
 
@@ -9,14 +11,14 @@ class MemoSpec extends AnyFlatSpec with Matchers {
 
   it should "memoize the result" in {
     var timesExecuted = 0
-    val random = new Memo[Int](Eval.delay {
+    val random = new Memo[Int](Sync[Eval].delay {
       timesExecuted += 1
       9
     })
     assert(timesExecuted == 0)
-    assert(random.get.value() == 9)
+    assert(random.get.value == 9)
     assert(timesExecuted == 1)
-    assert(random.get.value() == 9)
+    assert(random.get.value == 9)
     assert(timesExecuted == 1)
   }
 

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -7,7 +7,7 @@ import coop.rchain.models.Connective.ConnectiveInstance.{Empty => _}
 import coop.rchain.models.serialization.implicits._
 import coop.rchain.models.testImplicits._
 import coop.rchain.shared.Serialize
-import monix.eval.Coeval
+import cats.Eval
 import org.scalacheck.{Arbitrary, Shrink}
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
@@ -72,7 +72,7 @@ class RhoTypesTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matche
     // We also check `stacksafeDeserialize(referenceSerialize(a)).equals(a)` just in case :)
     val referenceBytes = a.toByteArray
     val in             = CodedInputStream.newInstance(referenceBytes)
-    val decoded        = companion.defaultInstance.mergeFromM[Coeval](in).value
+    val decoded        = companion.defaultInstance.mergeFromM[Eval](in).value
     val encoded        = decoded.toByteArray
     assert(encoded sameElements referenceBytes)
     assert(decoded == a)

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -14,6 +14,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scalapb.GeneratedMessageCompanion
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.collection.immutable.BitSet
 import scala.reflect.ClassTag
@@ -57,7 +58,7 @@ class RhoTypesTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matche
   }
 
   def stacksafeSizeSameAsReference[A <: StacksafeMessage[A]](a: A): Assertion =
-    assert(ProtoM.serializedSize(a).value() == a.serializedSize)
+    assert(ProtoM.serializedSize(a).value == a.serializedSize)
 
   def stacksafeWriteToSameAsReference[A <: StacksafeMessage[A]](a: A): Assertion =
     assert(ProtoM.toByteArray(a).value sameElements a.toByteArray)

--- a/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
@@ -16,6 +16,7 @@ import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.collection.immutable.BitSet
 
@@ -140,7 +141,7 @@ class SortedParHashSetSpec extends AnyFlatSpec with ScalaCheckPropertyChecks wit
   }
 
   def isSorted[A: Sortable](a: A): Boolean =
-    a == Sortable[A].sortMatch[Eval](a).value().term
+    a == Sortable[A].sortMatch[Eval](a).value.term
 
   private def checkSortedInput[A, B](f: A => B, unsorted: A, sorted: A): Assertion =
     assert(f(sorted) == f(unsorted))

--- a/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
@@ -11,7 +11,7 @@ import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.models.rholang.sorter.ordering._
 import coop.rchain.models.testImplicits._
 import coop.rchain.models.testUtils.TestUtils.sort
-import monix.eval.Coeval
+import cats.Eval
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -140,7 +140,7 @@ class SortedParHashSetSpec extends AnyFlatSpec with ScalaCheckPropertyChecks wit
   }
 
   def isSorted[A: Sortable](a: A): Boolean =
-    a == Sortable[A].sortMatch[Coeval](a).value().term
+    a == Sortable[A].sortMatch[Eval](a).value().term
 
   private def checkSortedInput[A, B](f: A => B, unsorted: A, sorted: A): Assertion =
     assert(f(sorted) == f(unsorted))

--- a/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
@@ -12,7 +12,7 @@ import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.models.rholang.sorter.ordering._
 import coop.rchain.models.testImplicits._
 import coop.rchain.models.testUtils.TestUtils.sort
-import monix.eval.Coeval
+import cats.Eval
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -177,5 +177,5 @@ class SortedParMapSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Ma
     assert(f(sorted) == f(unsorted))
 
   def isSorted[A: Sortable](a: A): Boolean =
-    a == Sortable[A].sortMatch[Coeval](a).value().term
+    a == Sortable[A].sortMatch[Eval](a).value().term
 }

--- a/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
@@ -17,6 +17,7 @@ import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 class SortedParMapSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
 
@@ -177,5 +178,5 @@ class SortedParMapSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Ma
     assert(f(sorted) == f(unsorted))
 
   def isSorted[A: Sortable](a: A): Boolean =
-    a == Sortable[A].sortMatch[Eval](a).value().term
+    a == Sortable[A].sortMatch[Eval](a).value.term
 }

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -10,7 +10,7 @@ import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.rholang.sorter._
 import coop.rchain.models.testUtils.TestUtils.forAllSimilarA
 import coop.rchain.models.{New, _}
-import monix.eval.Coeval
+import cats.Eval
 import org.scalacheck.Arbitrary
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -19,7 +19,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.collection.immutable.BitSet
 
 object SortTest {
-  def sort[T: Sortable](t: T) = Sortable[T].sortMatch[Coeval](t).value
+  def sort[T: Sortable](t: T) = Sortable[T].sortMatch[Eval](t).value
 }
 
 class ScoredTermSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
@@ -168,14 +168,14 @@ class ScoredTermSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matc
   }
   it should "sort so that unequal ParSet have unequal scores" in {
     val set1 =
-      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Coeval.delay(BitSet()), None)))
+      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Eval.delay(BitSet()), None)))
     val set2 =
-      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = false, Coeval.delay(BitSet()), None)))
+      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = false, Eval.delay(BitSet()), None)))
     assert(sort(set1).score != sort(set2).score)
     val set3 =
-      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Coeval.delay(BitSet()), None)))
+      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Eval.delay(BitSet()), None)))
     val set4 =
-      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Coeval.delay(BitSet()), Some(Var()))))
+      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Eval.delay(BitSet()), Some(Var()))))
     assert(sort(set3).score != sort(set4).score)
   }
   it should "sort so that unequal List have unequal scores" in {

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -11,10 +11,12 @@ import coop.rchain.models.rholang.sorter._
 import coop.rchain.models.testUtils.TestUtils.forAllSimilarA
 import coop.rchain.models.{New, _}
 import cats.Eval
+import cats.effect.Sync
 import org.scalacheck.Arbitrary
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.collection.immutable.BitSet
 
@@ -168,14 +170,16 @@ class ScoredTermSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matc
   }
   it should "sort so that unequal ParSet have unequal scores" in {
     val set1 =
-      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Eval.delay(BitSet()), None)))
+      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Sync[Eval].delay(BitSet()), None)))
     val set2 =
-      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = false, Eval.delay(BitSet()), None)))
+      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = false, Sync[Eval].delay(BitSet()), None)))
     assert(sort(set1).score != sort(set2).score)
     val set3 =
-      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Eval.delay(BitSet()), None)))
+      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Sync[Eval].delay(BitSet()), None)))
     val set4 =
-      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Eval.delay(BitSet()), Some(Var()))))
+      Expr(
+        ESetBody(ParSet(Seq.empty, connectiveUsed = true, Sync[Eval].delay(BitSet()), Some(Var())))
+      )
     assert(sort(set3).score != sort(set4).score)
   }
   it should "sort so that unequal List have unequal scores" in {

--- a/models/src/test/scala/coop/rchain/models/testImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/testImplicits.scala
@@ -1,7 +1,7 @@
 package coop.rchain.models
 
 import com.google.protobuf.ByteString
-import monix.eval.Coeval
+import cats.Eval
 import org.scalacheck.ScalacheckShapeless._
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 
@@ -27,8 +27,8 @@ object testImplicits {
     ps <- Arbitrary.arbitrary[Seq[(Par, Par)]]
   } yield SortedParMap(ps))
 
-  implicit def coeval[A: Arbitrary]: Arbitrary[Coeval[A]] =
-    Arbitrary(Arbitrary.arbitrary[A].map(a => Coeval.delay(a)))
+  implicit def Eval[A: Arbitrary]: Arbitrary[Eval[A]] =
+    Arbitrary(Arbitrary.arbitrary[A].map(a => Eval.delay(a)))
 
   //Par and Expr (or Par at least) need to be first here, or else the compiler dies terribly.
   implicit val ParArbitrary                = implicitly[Arbitrary[Par]]

--- a/models/src/test/scala/coop/rchain/models/testImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/testImplicits.scala
@@ -2,8 +2,10 @@ package coop.rchain.models
 
 import com.google.protobuf.ByteString
 import cats.Eval
+import cats.effect.Sync
 import org.scalacheck.ScalacheckShapeless._
 import org.scalacheck.{Arbitrary, Gen, Shrink}
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.collection.immutable.BitSet
 
@@ -28,7 +30,7 @@ object testImplicits {
   } yield SortedParMap(ps))
 
   implicit def Eval[A: Arbitrary]: Arbitrary[Eval[A]] =
-    Arbitrary(Arbitrary.arbitrary[A].map(a => Eval.delay(a)))
+    Arbitrary(Arbitrary.arbitrary[A].map(a => Sync[Eval].delay(a)))
 
   //Par and Expr (or Par at least) need to be first here, or else the compiler dies terribly.
   implicit val ParArbitrary                = implicitly[Arbitrary[Par]]

--- a/models/src/test/scala/coop/rchain/models/testUtils/TestUtils.scala
+++ b/models/src/test/scala/coop/rchain/models/testUtils/TestUtils.scala
@@ -1,14 +1,14 @@
 package coop.rchain.models.testUtils
 import coop.rchain.models.Par
 import coop.rchain.models.rholang.sorter.Sortable
-import monix.eval.Coeval
+import cats.Eval
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.Assertion
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks._
 
 object TestUtils {
-  def sort(par: Par): Par                                            = Sortable[Par].sortMatch[Coeval](par).map(_.term).value()
+  def sort(par: Par): Par                                            = Sortable[Par].sortMatch[Eval](par).map(_.term).value()
   def forAllSimilarA[A: Arbitrary](block: (A, A) => Assertion): Unit =
     // ScalaCheck generates similar A-s in subsequent calls which
     // we need to hit the case where `x == y` more often

--- a/models/src/test/scala/coop/rchain/models/testUtils/TestUtils.scala
+++ b/models/src/test/scala/coop/rchain/models/testUtils/TestUtils.scala
@@ -6,9 +6,10 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.Assertion
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks._
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 object TestUtils {
-  def sort(par: Par): Par                                            = Sortable[Par].sortMatch[Eval](par).map(_.term).value()
+  def sort(par: Par): Par                                            = Sortable[Par].sortMatch[Eval](par).map(_.term).value
   def forAllSimilarA[A: Arbitrary](block: (A, A) => Assertion): Unit =
     // ScalaCheck generates similar A-s in subsequent calls which
     // we need to hit the case where `x == y` more often

--- a/project/StacksafeScalapbGenerator.scala
+++ b/project/StacksafeScalapbGenerator.scala
@@ -119,9 +119,13 @@ class StacksafeMessagePrinter(
       fp: FunctionalPrinter
   ): FunctionalPrinter = {
     val myFullScalaName = message.scalaType.fullNameWithMaybeRoot(message)
-    fp.add(
-        s"override def equals(x: Any): Boolean = coop.rchain.models.EqualM[$myFullScalaName].equals[monix.eval.Coeval](this, x).value"
-      )
+    fp.add(s"override def equals(x: Any): Boolean = {")
+      .newline
+      .add("  import coop.rchain.catscontrib.effect.implicits.sEval")
+      .newline
+      .add(s" coop.rchain.models.EqualM[$myFullScalaName].equals[cats.Eval](this, x).value")
+      .newline
+      .add("}")
       .newline
   }
 
@@ -131,10 +135,15 @@ class StacksafeMessagePrinter(
   ): FunctionalPrinter = {
     val myFullScalaName = message.scalaType.fullNameWithMaybeRoot(message)
 
-    val printer = fp
-      .add(
-        s"override def hashCode(): Int = coop.rchain.models.HashM[$myFullScalaName].hash[monix.eval.Coeval](this).value"
-      )
+    val printer =
+      fp.add(s"override def hashCode(): Int = {")
+        .newline
+        .add("  import coop.rchain.catscontrib.effect.implicits.sEval")
+        .newline
+        .add(s" coop.rchain.models.HashM[$myFullScalaName].hash[cats.Eval](this).value")
+        .newline
+        .add("}")
+        .newline
 
     // In new version of scalapb (0.10.8) `merge` method is moved to companion object
     //  so it's added here to be a member method.

--- a/rholang/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
@@ -2,7 +2,7 @@ package coop.rchain.rholang.build
 import coop.rchain.models.NormalizerEnv.ToEnvMap
 import coop.rchain.models.{NormalizerEnv, Par}
 import coop.rchain.rholang.interpreter.compiler.Compiler
-import monix.eval.Coeval
+import cats.Eval
 import shapeless.HNil
 
 import scala.io.Source
@@ -12,7 +12,7 @@ abstract class CompiledRholangSource[Env](val code: String, val normalizerEnv: N
     implicit ev: ToEnvMap[Env]
 ) {
   val path: String
-  val term: Par = Compiler[Coeval].sourceToADT(code, normalizerEnv.toEnv).value()
+  val term: Par = Compiler[Eval].sourceToADT(code, normalizerEnv.toEnv).value
   final def env = normalizerEnv.toEnv
 }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
@@ -12,6 +12,8 @@ abstract class CompiledRholangSource[Env](val code: String, val normalizerEnv: N
     implicit ev: ToEnvMap[Env]
 ) {
   val path: String
+
+  import coop.rchain.catscontrib.effect.implicits.sEval
   val term: Par = Compiler[Eval].sourceToADT(code, normalizerEnv.toEnv).value
   final def env = normalizerEnv.toEnv
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/CollectionNormalizeMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/CollectionNormalizeMatcher.scala
@@ -16,7 +16,7 @@ import coop.rchain.models.{
 }
 import coop.rchain.rholang.ast.rholang_mercury.Absyn.{KeyValuePair => AbsynKeyValuePair, _}
 import coop.rchain.rholang.interpreter.compiler._
-import monix.eval.Coeval
+import cats.Eval
 
 import scala.collection.convert.ImplicitConversionsToScala._
 import scala.collection.immutable.{BitSet, Vector}
@@ -132,7 +132,7 @@ object CollectionNormalizeMatcher {
                 optionalRemainder =>
                   (pars, locallyFree, connectiveUsed) => {
                     val tmpParSet =
-                      ParSet(pars, connectiveUsed, Coeval.delay(locallyFree.get), optionalRemainder)
+                      ParSet(pars, connectiveUsed, Eval.later(locallyFree.get()), optionalRemainder)
                     tmpParSet.copy(
                       connectiveUsed = tmpParSet.connectiveUsed || optionalRemainder.isDefined
                     )

--- a/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
@@ -10,6 +10,7 @@ import org.scalacheck.Test.Parameters
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 class ProcGenTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
   implicit val params: Parameters = Parameters.defaultVerbose.withMinSuccessfulTests(1000)
@@ -21,7 +22,7 @@ class ProcGenTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matcher
   it should "generate correct procs that are normalized successfully" in {
 
     forAll { p: PrettyPrinted[Proc] =>
-      Compiler[Eval].astToADT(p.value).apply
+      Compiler[Eval].astToADT(p.value)
     }
   }
 
@@ -32,7 +33,7 @@ class ProcGenTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matcher
       ProcGen.procShrinker
         .shrink(original.value)
         .headOption
-        .map(shrinked => Compiler[Eval].astToADT(shrinked).apply)
+        .map(shrinked => Compiler[Eval].astToADT(shrinked))
         .getOrElse(true)
 
     }

--- a/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
@@ -4,7 +4,7 @@ import coop.rchain.models.PrettyPrinted
 import coop.rchain.rholang.interpreter.compiler.Compiler
 import coop.rchain.rholang.ast.rholang_mercury.Absyn._
 import coop.rchain.rholang.ast.rholang_mercury.PrettyPrinter
-import monix.eval.Coeval
+import cats.Eval
 import org.scalacheck.Arbitrary
 import org.scalacheck.Test.Parameters
 import org.scalatest.flatspec.AnyFlatSpec
@@ -21,7 +21,7 @@ class ProcGenTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matcher
   it should "generate correct procs that are normalized successfully" in {
 
     forAll { p: PrettyPrinted[Proc] =>
-      Compiler[Coeval].astToADT(p.value).apply
+      Compiler[Eval].astToADT(p.value).apply
     }
   }
 
@@ -32,7 +32,7 @@ class ProcGenTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matcher
       ProcGen.procShrinker
         .shrink(original.value)
         .headOption
-        .map(shrinked => Compiler[Coeval].astToADT(shrinked).apply)
+        .map(shrinked => Compiler[Eval].astToADT(shrinked).apply)
         .getOrElse(true)
 
     }

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -13,7 +13,7 @@ import coop.rchain.rholang.syntax._
 import coop.rchain.rholang.interpreter.compiler.Compiler
 import coop.rchain.rholang.interpreter.{Interpreter, InterpreterUtil, ParBuilderUtil, PrettyPrinter}
 import coop.rchain.shared.{Log, Serialize}
-import monix.eval.{Coeval, Task}
+import monix.eval.{Eval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.Assertions
@@ -198,7 +198,7 @@ class StackSafetySpec extends AnyFlatSpec with TableDrivenPropertyChecks with Ma
          |""".stripMargin
 
     isolateStackOverflow {
-      val ast = Compiler[Coeval].sourceToADT(rho).value()
+      val ast = Compiler[Eval].sourceToADT(rho).value()
       PrettyPrinter().buildString(ast)
       checkSuccess(rho) {
         mkRuntime[Task](tmpPrefix).use { runtime =>
@@ -242,10 +242,10 @@ class AstTypeclassesStackSafetySpec extends AnyFlatSpec with Matchers {
       val encoded = Serialize[Par].encode(par)
       Serialize[Par].decode(encoded)
 
-      HashM[Par].hash[Coeval](par).value
+      HashM[Par].hash[Eval](par).value
       par.hashCode()
 
-      EqualM[Par].equal[Coeval](par, anotherPar).value
+      EqualM[Par].equal[Eval](par, anotherPar).value
       par == anotherPar
 
     }

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -1,5 +1,6 @@
 package coop.rchain.rholang
 
+import cats.Eval
 import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.Connective.ConnectiveInstance.ConnNotBody
@@ -13,12 +14,13 @@ import coop.rchain.rholang.syntax._
 import coop.rchain.rholang.interpreter.compiler.Compiler
 import coop.rchain.rholang.interpreter.{Interpreter, InterpreterUtil, ParBuilderUtil, PrettyPrinter}
 import coop.rchain.shared.{Log, Serialize}
-import monix.eval.{Eval, Task}
+import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.Assertions
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._
@@ -198,7 +200,7 @@ class StackSafetySpec extends AnyFlatSpec with TableDrivenPropertyChecks with Ma
          |""".stripMargin
 
     isolateStackOverflow {
-      val ast = Compiler[Eval].sourceToADT(rho).value()
+      val ast = Compiler[Eval].sourceToADT(rho).value
       PrettyPrinter().buildString(ast)
       checkSuccess(rho) {
         mkRuntime[Task](tmpPrefix).use { runtime =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -237,7 +237,7 @@ class CryptoChannelsSpec
   }
 
   /** TODO(mateusz.gorski): once we refactor Rholang[AndScala]Dispatcher
-    *  to push effect choice up until declaration site refactor to `Reduce[Coeval]`
+    *  to push effect choice up until declaration site refactor to `Reduce[Eval]`
     */
   override type FixtureParam = RhoRuntime[Task]
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
@@ -7,11 +7,14 @@ import cats.Eval
 import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 class LexerTest extends AnyFlatSpec with Matchers {
 
   def attemptMkTerm(input: String): Either[Throwable, Par] =
-    Compiler[Eval].sourceToADT(input).runAttempt()
+    try {
+      Right(Compiler[Eval].sourceToADT(input).value)
+    } catch { case x: Throwable => Left(x) }
 
   "Lexer" should "return LexerError for unterminated string at EOF" in {
     val attempt = attemptMkTerm("""{{ @"ack!(0) }}""")

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
@@ -3,7 +3,7 @@ package coop.rchain.rholang.interpreter
 import coop.rchain.rholang.interpreter.compiler.Compiler
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.errors.LexerError
-import monix.eval.Coeval
+import cats.Eval
 import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -11,7 +11,7 @@ import org.scalatest.matchers.should.Matchers
 class LexerTest extends AnyFlatSpec with Matchers {
 
   def attemptMkTerm(input: String): Either[Throwable, Par] =
-    Compiler[Coeval].sourceToADT(input).runAttempt()
+    Compiler[Eval].sourceToADT(input).runAttempt()
 
   "Lexer" should "return LexerError for unterminated string at EOF" in {
     val attempt = attemptMkTerm("""{{ @"ack!(0) }}""")

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
@@ -6,11 +6,14 @@ import cats.Eval
 import org.scalatest.EitherValues._
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 object ParBuilderUtil {
 
   def mkTerm(rho: String): Either[Throwable, Par] =
-    Compiler[Eval].sourceToADT(rho, Map.empty[String, Par]).runAttempt
+    try {
+      Right(Compiler[Eval].sourceToADT(rho, Map.empty[String, Par]).value)
+    } catch { case x: Throwable => Left(x) }
 
   def assertCompiledEqual(s: String, t: String): Assertion =
     ParBuilderUtil.mkTerm(s).value shouldBe ParBuilderUtil.mkTerm(t).value

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
@@ -2,7 +2,7 @@ package coop.rchain.rholang.interpreter
 
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.compiler.Compiler
-import monix.eval.Coeval
+import cats.Eval
 import org.scalatest.EitherValues._
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 object ParBuilderUtil {
 
   def mkTerm(rho: String): Either[Throwable, Par] =
-    Compiler[Coeval].sourceToADT(rho, Map.empty[String, Par]).runAttempt
+    Compiler[Eval].sourceToADT(rho, Map.empty[String, Par]).runAttempt
 
   def assertCompiledEqual(s: String, t: String): Assertion =
     ParBuilderUtil.mkTerm(s).value shouldBe ParBuilderUtil.mkTerm(t).value

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -23,7 +23,7 @@ import coop.rchain.rholang.interpreter.compiler.normalizer.{
   NameNormalizeMatcher
 }
 import coop.rchain.rholang.ast.rholang_mercury.Absyn._
-import monix.eval.Coeval
+import cats.Eval
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -48,25 +48,25 @@ class GroundPrinterSpec extends AnyFlatSpec with Matchers {
   "GroundInt" should "Print as \"" + 7 + "\"" in {
     val gi             = new GroundInt("7")
     val target: String = "7"
-    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch[Coeval](gi).value) shouldBe target
+    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch[Eval](gi).value) shouldBe target
   }
 
   "GroundBigInt" should "Print as \" 9999999999999999999999999999999999999999 \"" in {
     val gbi            = new GroundBigInt("9999999999999999999999999999999999999999")
     val target: String = "BigInt(9999999999999999999999999999999999999999)"
-    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch[Coeval](gbi).value) shouldBe target
+    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch[Eval](gbi).value) shouldBe target
   }
 
   "GroundString" should "Print as \"" + "String" + "\"" in {
     val gs             = new GroundString("\"String\"")
     val target: String = "\"" + "String" + "\""
-    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch[Coeval](gs).value) shouldBe target
+    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch[Eval](gs).value) shouldBe target
   }
 
   "GroundUri" should "Print with back-ticks" in {
     val gu             = new GroundUri("`Uri`")
     val target: String = "`" + "Uri" + "`"
-    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch[Coeval](gu).value) shouldBe target
+    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch[Eval](gu).value) shouldBe target
   }
 }
 
@@ -91,7 +91,7 @@ class CollectPrinterSpec extends AnyFlatSpec with Matchers {
 
     val result =
       PrettyPrinter(0, 2).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](list, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](list, inputs).value.par
       )
     result shouldBe "[x0, x1, 7...free0]"
   }
@@ -106,7 +106,7 @@ class CollectPrinterSpec extends AnyFlatSpec with Matchers {
 
     val result =
       PrettyPrinter(0, 2).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](list, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](list, inputs).value.par
       )
     result shouldBe "Set(7, x1, x0...free0)"
   }
@@ -124,7 +124,7 @@ class CollectPrinterSpec extends AnyFlatSpec with Matchers {
 
     val result =
       PrettyPrinter(0, 2).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](map, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](map, inputs).value.par
       )
     result shouldBe "{7 : \"" + "Seven" + "\", x0 : x1...free0}"
   }
@@ -153,7 +153,7 @@ class CollectPrinterSpec extends AnyFlatSpec with Matchers {
 
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](map, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](map, inputs).value.par
       )
     val target = """{"a" : 1, "b" : 2, "c" : 3}"""
     result shouldBe target
@@ -267,7 +267,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val source = new PNew(nameDec, receive)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](source, inputs).value.par
       )
     val target =
       """new x0 in {
@@ -299,7 +299,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val source = new PNew(nameDec, receive)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](source, inputs).value.par
       )
     val target =
       """new x0 in {
@@ -345,7 +345,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val source = new PNew(nameDec, receive)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](source, inputs).value.par
       )
     val target =
       """new x0, x1 in {
@@ -392,7 +392,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val source = new PNew(nameDec, receive)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](source, inputs).value.par
       )
     val target =
       """new x0, x1 in {
@@ -444,7 +444,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val source = new PNew(nameDec, receive)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](source, inputs).value.par
       )
     val target =
       """new x0, x1 in {
@@ -484,7 +484,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val source = new PNew(nameDec, body)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](source, inputs).value.par
       )
     val target =
       """new x0 in {
@@ -499,7 +499,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
   "PNil" should "Print" in {
     val nil = new PNil()
     val result = PrettyPrinter().buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](nil, inputs).value.par
+      ProcNormalizeMatcher.normalizeMatch[Eval](nil, inputs).value.par
     )
     result shouldBe "Nil"
   }
@@ -510,7 +510,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
       inputs.copy(boundMapChain = inputs.boundMapChain.put(("x", ProcSort, SourcePosition(0, 0))))
     val result =
       PrettyPrinter(0, 1).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](pvar, boundInputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](pvar, boundInputs).value.par
       )
     result shouldBe "x0"
   }
@@ -536,7 +536,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
       inputs.copy(boundMapChain = inputs.boundMapChain.put(("x", NameSort, SourcePosition(0, 0))))
     val result =
       PrettyPrinter(0, 1).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](pEval, boundInputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](pEval, boundInputs).value.par
       )
     result shouldBe "x0"
   }
@@ -549,7 +549,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
       inputs.copy(boundMapChain = inputs.boundMapChain.put(("x", ProcSort, SourcePosition(0, 0))))
     val result =
       PrettyPrinter(0, 1).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](pEval, boundInputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](pEval, boundInputs).value.par
       )
     result shouldBe
       """x0 |
@@ -598,7 +598,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     sentData.add(new PGround(new GroundInt("8")))
     val pSend = new PSend(new NameQuote(new PNil()), new SendSingle(), sentData)
     val result = PrettyPrinter().buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](pSend, inputs).value.par
+      ProcNormalizeMatcher.normalizeMatch[Eval](pSend, inputs).value.par
     )
     result shouldBe "@{Nil}!(7, 8)"
   }
@@ -612,7 +612,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
       inputs.copy(boundMapChain = inputs.boundMapChain.put(("x", NameSort, SourcePosition(0, 0))))
     val result =
       PrettyPrinter(0, 1).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](pSend, boundInputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](pSend, boundInputs).value.par
       )
     result shouldBe "@{x0}!(7, 8)"
   }
@@ -621,7 +621,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val parGround = new PPar(new PGround(new GroundInt("7")), new PGround(new GroundInt("8")))
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](parGround, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](parGround, inputs).value.par
       )
     result shouldBe
       """8 |
@@ -633,7 +633,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val boundInputs =
       inputs.copy(boundMapChain = inputs.boundMapChain.put(("x", ProcSort, SourcePosition(0, 0))))
     val result = PrettyPrinter(0, 1).buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](parDoubleBound, boundInputs).value.par
+      ProcNormalizeMatcher.normalizeMatch[Eval](parDoubleBound, boundInputs).value.par
     )
     result shouldBe
       """x0 |
@@ -644,7 +644,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val parDoubleFree = new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("y")))
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](parDoubleFree, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](parDoubleFree, inputs).value.par
       )
     result shouldBe
       """free1 |
@@ -695,7 +695,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val basicInput1 = new PInput(listReceipt1, body1)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput1, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](basicInput1, inputs).value.par
       )
     val target =
       """for( @{x0}, @{for( @{y0}, @{y1} <- @{Nil} ) { y1 | y0 | x1 }} <- @{Nil} ) {
@@ -769,7 +769,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val pInput = new PNew(listNameDecl, new PInput(listReceipt, body3))
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](pInput, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](pInput, inputs).value.par
       )
     result shouldBe
       """new x0, x1 in {
@@ -817,7 +817,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val result = PrettyPrinter()
       .buildString(
         ProcNormalizeMatcher
-          .normalizeMatch[Coeval](pNew, inputs)
+          .normalizeMatch[Eval](pNew, inputs)
           .value
           .par
       )
@@ -858,7 +858,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
       send47OnNil
     )
     val result = PrettyPrinter().buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](pPar, inputs).value.par
+      ProcNormalizeMatcher.normalizeMatch[Eval](pPar, inputs).value.par
     )
     result shouldBe
       """@{Nil}!(47) |
@@ -894,7 +894,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val basicInput = new PIf(condition, body)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](basicInput, inputs).value.par
       )
     result shouldBe
       """match true {
@@ -929,7 +929,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val basicInput = new PIfElse(condition, pNewIf, pNewElse)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput, inputs).value.par
+        ProcNormalizeMatcher.normalizeMatch[Eval](basicInput, inputs).value.par
       )
     result shouldBe
       """match (47 == 47) {
@@ -968,7 +968,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     listReceipt.add(receipt)
     val input = new PInput(listReceipt, new PNil())
     val result = PrettyPrinter().buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](input, inputs).value.par
+      ProcNormalizeMatcher.normalizeMatch[Eval](input, inputs).value.par
     )
     result shouldBe """for( @{match x0 | x1 { 47 => { Nil } }} <- @{Nil} ) {
                       |  Nil
@@ -979,7 +979,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val pMatches = new PMatches(new PGround(new GroundInt("1")), new PVar(new ProcVarWildcard()))
 
     val result = PrettyPrinter(0, 1).buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](pMatches, inputs).value.par
+      ProcNormalizeMatcher.normalizeMatch[Eval](pMatches, inputs).value.par
     )
 
     result shouldBe "(1 matches _)"
@@ -989,7 +989,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     assert(parseAndPrint(prettySource) == prettySource)
 
   private def parseAndPrint(source: String): String = PrettyPrinter().buildString(
-    Compiler[Coeval].sourceToADT(new StringReader(source)).runAttempt().right.get
+    Compiler[Eval].sourceToADT(new StringReader(source)).runAttempt().right.get
   )
 }
 
@@ -1030,7 +1030,7 @@ class NamePrinterSpec extends AnyFlatSpec with Matchers {
   "NameWildcard" should "Print" in {
     val nw = new NameWildcard()
     val result = PrettyPrinter().buildString(
-      NameNormalizeMatcher.normalizeMatch[Coeval](nw, inputs).value.par
+      NameNormalizeMatcher.normalizeMatch[Eval](nw, inputs).value.par
     )
     result shouldBe "_"
   }
@@ -1042,7 +1042,7 @@ class NamePrinterSpec extends AnyFlatSpec with Matchers {
       inputs.copy(boundMapChain = inputs.boundMapChain.put(("x", NameSort, SourcePosition(0, 0))))
     val result =
       PrettyPrinter(0, 1).buildString(
-        NameNormalizeMatcher.normalizeMatch[Coeval](nvar, boundInputs).value.par
+        NameNormalizeMatcher.normalizeMatch[Eval](nvar, boundInputs).value.par
       )
     result shouldBe "x0"
   }
@@ -1055,7 +1055,7 @@ class NamePrinterSpec extends AnyFlatSpec with Matchers {
       inputs.copy(boundMapChain = inputs.boundMapChain.put(("x", NameSort, SourcePosition(0, 0))))
     val result =
       PrettyPrinter(0, 1).buildString(
-        NameNormalizeMatcher.normalizeMatch[Coeval](nqeval, boundInputs).value.par
+        NameNormalizeMatcher.normalizeMatch[Eval](nqeval, boundInputs).value.par
       )
     result shouldBe "x0 |\nx0"
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -27,6 +27,7 @@ import cats.Eval
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.collection.immutable.BitSet
 
@@ -989,7 +990,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     assert(parseAndPrint(prettySource) == prettySource)
 
   private def parseAndPrint(source: String): String = PrettyPrinter().buildString(
-    Compiler[Eval].sourceToADT(new StringReader(source)).runAttempt().right.get
+    Compiler[Eval].sourceToADT(new StringReader(source)).value
   )
 }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReceiveSortMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReceiveSortMatcherSpec.scala
@@ -3,7 +3,7 @@ package coop.rchain.rholang.interpreter
 import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models.{Par, ReceiveBind, Var}
 import coop.rchain.models.Var.VarInstance.FreeVar
-import monix.eval.Coeval
+import cats.Eval
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import coop.rchain.models.rholang.implicits._
@@ -74,7 +74,7 @@ class ReceiveSortMatcherSpec extends AnyFlatSpec with Matchers {
           emptyMap
         )
       )
-    val result = ReceiveBindsSortMatcher.preSortBinds[Coeval, VarSort](binds).value
+    val result = ReceiveBindsSortMatcher.preSortBinds[Eval, VarSort](binds).value
     result should be(sortedBinds)
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReceiveSortMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReceiveSortMatcherSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.compiler.{FreeMap, ReceiveBindsSortMatcher, VarSort}
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 class ReceiveSortMatcherSpec extends AnyFlatSpec with Matchers {
   val emptyMap = FreeMap.empty[VarSort]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import coop.rchain.models.rholang.sorter.ScoredTerm
 import cats.Eval
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.collection.immutable.BitSet
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
@@ -6,7 +6,7 @@ import coop.rchain.models.rholang.sorter.Sortable
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import coop.rchain.models.rholang.sorter.ScoredTerm
-import monix.eval.Coeval
+import cats.Eval
 
 import scala.collection.immutable.BitSet
 
@@ -45,7 +45,7 @@ class SortSpec extends AnyFlatSpec with Matchers {
   }
 
   def checkSortingAndScore[T: Sortable](term: T): ScoredTerm[T] = {
-    val scored: ScoredTerm[T] = Sortable[T].sortMatch[Coeval](term).value
+    val scored: ScoredTerm[T] = Sortable[T].sortMatch[Eval](term).value
     assert(scored.term == term, "Either input term not sorted or sorting returned wrong results")
     scored
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
@@ -13,6 +13,7 @@ import org.scalacheck.Gen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.collection.immutable.BitSet
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -14,7 +14,7 @@ import coop.rchain.rholang.ast.rholang_mercury.PrettyPrinter
 import coop.rchain.rholang.syntax._
 import coop.rchain.rholang.{GenTools, ProcGen}
 import coop.rchain.shared.Log
-import monix.eval.{Coeval, Task}
+import monix.eval.{Eval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.Test.Parameters
 import org.scalacheck.{Arbitrary, Gen}
@@ -35,7 +35,7 @@ class CostAccountingPropertyTest extends AnyFlatSpec with ScalaCheckPropertyChec
 
   implicit val taskExecutionDuration: FiniteDuration = 5.seconds
 
-  def cost(proc: Proc): Cost = Cost(Compiler[Coeval].astToADT(proc).apply)
+  def cost(proc: Proc): Cost = Cost(Compiler[Eval].astToADT(proc).apply)
 
   behavior of "Cost accounting in Reducer"
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -14,13 +14,14 @@ import coop.rchain.rholang.ast.rholang_mercury.PrettyPrinter
 import coop.rchain.rholang.syntax._
 import coop.rchain.rholang.{GenTools, ProcGen}
 import coop.rchain.shared.Log
-import monix.eval.{Eval, Task}
+import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.Test.Parameters
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.concurrent.duration._
 
@@ -35,7 +36,7 @@ class CostAccountingPropertyTest extends AnyFlatSpec with ScalaCheckPropertyChec
 
   implicit val taskExecutionDuration: FiniteDuration = 5.seconds
 
-  def cost(proc: Proc): Cost = Cost(Compiler[Eval].astToADT(proc).apply)
+  def cost(proc: Proc): Cost = Cost(Compiler[Eval].astToADT(proc).value)
 
   behavior of "Cost accounting in Reducer"
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/CollectMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/CollectMatcherSpec.scala
@@ -24,6 +24,7 @@ import coop.rchain.rholang.interpreter.compiler.{
   VarSort
 }
 import cats.Eval
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 class CollectMatcherSpec extends AnyFlatSpec with Matchers {
   val inputs = ProcVisitInputs(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/CollectMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/CollectMatcherSpec.scala
@@ -23,7 +23,7 @@ import coop.rchain.rholang.interpreter.compiler.{
   SourcePosition,
   VarSort
 }
-import monix.eval.Coeval
+import cats.Eval
 
 class CollectMatcherSpec extends AnyFlatSpec with Matchers {
   val inputs = ProcVisitInputs(
@@ -45,7 +45,7 @@ class CollectMatcherSpec extends AnyFlatSpec with Matchers {
     listData.add(new PGround(new GroundInt("7")))
     val list = new PCollect(new CollectList(listData, new ProcRemainderEmpty()))
 
-    val result = ProcNormalizeMatcher.normalizeMatch[Coeval](list, inputs).value
+    val result = ProcNormalizeMatcher.normalizeMatch[Eval](list, inputs).value
     result.par should be(
       inputs.par.prepend(
         EList(
@@ -89,7 +89,7 @@ class CollectMatcherSpec extends AnyFlatSpec with Matchers {
     val tuple =
       new PCollect(new CollectTuple(new TupleMultiple(new PVar(new ProcVarVar("Q")), tupleData)))
 
-    val result = ProcNormalizeMatcher.normalizeMatch[Coeval](tuple, inputs).value
+    val result = ProcNormalizeMatcher.normalizeMatch[Eval](tuple, inputs).value
     result.par should be(
       inputs.par.prepend(
         ETuple(
@@ -117,7 +117,7 @@ class CollectMatcherSpec extends AnyFlatSpec with Matchers {
       new PCollect(new CollectTuple(new TupleMultiple(new PVar(new ProcVarVar("Q")), tupleData)))
 
     an[UnexpectedReuseOfProcContextFree] should be thrownBy {
-      ProcNormalizeMatcher.normalizeMatch[Coeval](tuple, inputs).value
+      ProcNormalizeMatcher.normalizeMatch[Eval](tuple, inputs).value
     }
   }
   "Tuple" should "sort the insides of their elements" in {
@@ -130,7 +130,7 @@ class CollectMatcherSpec extends AnyFlatSpec with Matchers {
     setData.add(new PPar(new PGround(new GroundInt("8")), new PVar(new ProcVarVar("Q"))))
     val set = new PCollect(new CollectSet(setData, new ProcRemainderVar(new ProcVarVar("Z"))))
 
-    val result = ProcNormalizeMatcher.normalizeMatch[Coeval](set, inputs).value
+    val result = ProcNormalizeMatcher.normalizeMatch[Eval](set, inputs).value
 
     result.par should be(
       inputs.par.prepend(
@@ -166,7 +166,7 @@ class CollectMatcherSpec extends AnyFlatSpec with Matchers {
     mapData.add(new KeyValuePairImpl(new PVar(new ProcVarVar("P")), new PEval(new NameVar("Q"))))
     val map = new PCollect(new CollectMap(mapData, new ProcRemainderVar(new ProcVarVar("Z"))))
 
-    val result = ProcNormalizeMatcher.normalizeMatch[Coeval](map, inputs).value
+    val result = ProcNormalizeMatcher.normalizeMatch[Eval](map, inputs).value
     result.par should be(
       inputs.par.prepend(
         ParMap(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundMatcherSpec.scala
@@ -9,6 +9,7 @@ import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import cats.Eval
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 class GroundMatcherSpec extends AnyFlatSpec with Matchers {
   "GroundInt" should "Compile as GInt" in {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundMatcherSpec.scala
@@ -8,27 +8,27 @@ import org.scalatest.matchers.should.Matchers
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
-import monix.eval.Coeval
+import cats.Eval
 
 class GroundMatcherSpec extends AnyFlatSpec with Matchers {
   "GroundInt" should "Compile as GInt" in {
     val gi                   = new GroundInt("7")
     val expectedResult: Expr = GInt(7)
-    GroundNormalizeMatcher.normalizeMatch[Coeval](gi).value should be(expectedResult)
+    GroundNormalizeMatcher.normalizeMatch[Eval](gi).value should be(expectedResult)
   }
   "Positive groundBigInt" should "Compile GBigInt" in {
     val gbi                  = new GroundBigInt("9999999999999999999999999999999999999999")
     val expectedResult: Expr = GBigInt(BigInt("9999999999999999999999999999999999999999"))
-    GroundNormalizeMatcher.normalizeMatch[Coeval](gbi).value should be(expectedResult)
+    GroundNormalizeMatcher.normalizeMatch[Eval](gbi).value should be(expectedResult)
   }
   "GroundString" should "Compile as GString" in {
     val gs                   = new GroundString("\"String\"")
     val expectedResult: Expr = GString("String")
-    GroundNormalizeMatcher.normalizeMatch[Coeval](gs).value should be(expectedResult)
+    GroundNormalizeMatcher.normalizeMatch[Eval](gs).value should be(expectedResult)
   }
   "GroundUri" should "Compile as GUri" in {
     val gu                   = new GroundUri("`rho:uri`")
     val expectedResult: Expr = GUri("rho:uri")
-    GroundNormalizeMatcher.normalizeMatch[Coeval](gu).value should be(expectedResult)
+    GroundNormalizeMatcher.normalizeMatch[Eval](gu).value should be(expectedResult)
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/NameMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/NameMatcherSpec.scala
@@ -18,6 +18,7 @@ import coop.rchain.rholang.interpreter.compiler.{
   VarSort
 }
 import cats.Eval
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 class NameMatcherSpec extends AnyFlatSpec with Matchers {
   val inputs                                   = NameVisitInputs(BoundMapChain.empty[VarSort], FreeMap.empty[VarSort])

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/ProcMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/ProcMatcherSpec.scala
@@ -19,6 +19,7 @@ import cats.Eval
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import coop.rchain.catscontrib.effect.implicits.sEval
 
 import scala.collection.immutable.BitSet
 
@@ -247,45 +248,45 @@ class ProcMatcherSpec extends AnyFlatSpec with Matchers {
 
   "PSend" should "Not compile if data contains negation" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Compiler[Eval].sourceToADT("""new x in { x!(~1) }""").value()
+      Compiler[Eval].sourceToADT("""new x in { x!(~1) }""").value
     }
   }
 
   "PSend" should "Not compile if data contains conjunction" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Compiler[Eval].sourceToADT("""new x in { x!(1 /\ 2) }""").value()
+      Compiler[Eval].sourceToADT("""new x in { x!(1 /\ 2) }""").value
     }
   }
 
   "PSend" should "Not compile if data contains disjunction" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Compiler[Eval].sourceToADT("""new x in { x!(1 \/ 2) }""").value()
+      Compiler[Eval].sourceToADT("""new x in { x!(1 \/ 2) }""").value
     }
   }
 
   "PSend" should "Not compile if data contains wildcard" in {
     an[TopLevelWildcardsNotAllowedError] should be thrownBy {
-      Compiler[Eval].sourceToADT("""@"x"!(_)""").value()
+      Compiler[Eval].sourceToADT("""@"x"!(_)""").value
     }
   }
 
   "PSend" should "Not compile if data contains free variable" in {
     an[TopLevelFreeVariablesNotAllowedError] should be thrownBy {
-      Compiler[Eval].sourceToADT("""@"x"!(y)""").value()
+      Compiler[Eval].sourceToADT("""@"x"!(y)""").value
     }
   }
 
   "PSend" should "not compile if name contains connectives" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Compiler[Eval].sourceToADT("""@{Nil /\ Nil}!(1)""").value()
+      Compiler[Eval].sourceToADT("""@{Nil /\ Nil}!(1)""").value
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Compiler[Eval].sourceToADT("""@{Nil \/ Nil}!(1)""").value()
+      Compiler[Eval].sourceToADT("""@{Nil \/ Nil}!(1)""").value
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Compiler[Eval].sourceToADT("""@{~Nil}!(1)""").value()
+      Compiler[Eval].sourceToADT("""@{~Nil}!(1)""").value
     }
   }
 
@@ -485,7 +486,7 @@ class ProcMatcherSpec extends AnyFlatSpec with Matchers {
     (for {
       basicInput <- Compiler[Eval].sourceToAST("""for ( x, y <<- @Nil ) { x!(*y) }""")
       result     <- ProcNormalizeMatcher.normalizeMatch[Eval](basicInput, inputs)
-    } yield result.par.receives.head.peek shouldBe true).value()
+    } yield result.par.receives.head.peek shouldBe true).value
   }
 
   "PInput" should "Handle a more complicated receive" in {
@@ -650,19 +651,19 @@ class ProcMatcherSpec extends AnyFlatSpec with Matchers {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""for(x <- @{Nil \/ Nil}){ Nil }""")
-        .value()
+        .value
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""for(x <- @{Nil /\ Nil}){ Nil }""")
-        .value()
+        .value
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""for(x <- @{~Nil}){ Nil }""")
-        .value()
+        .value
     }
   }
 
@@ -670,19 +671,19 @@ class ProcMatcherSpec extends AnyFlatSpec with Matchers {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""for(x <- @Nil){ 1 /\ 2 }""")
-        .value()
+        .value
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""for(x <- @Nil){ 1 \/ 2 }""")
-        .value()
+        .value
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""for(x <- @Nil){ ~1 }""")
-        .value()
+        .value
     }
   }
 
@@ -690,13 +691,13 @@ class ProcMatcherSpec extends AnyFlatSpec with Matchers {
     an[PatternReceiveError] should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""new x in { for(@{Nil \/ Nil} <- x) { Nil } }""")
-        .value()
+        .value
     }
 
     an[PatternReceiveError] should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""new x in { for(@{~Nil} <- x) { Nil } }""")
-        .value()
+        .value
     }
   }
 
@@ -704,7 +705,7 @@ class ProcMatcherSpec extends AnyFlatSpec with Matchers {
     noException should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""new x in { for(@{Nil /\ Nil} <- x) { Nil } }""")
-        .value()
+        .value
     }
   }
 
@@ -712,13 +713,13 @@ class ProcMatcherSpec extends AnyFlatSpec with Matchers {
     an[PatternReceiveError] should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""new x in { contract x(@{ y /\ {Nil \/ Nil}}) = { Nil } }""")
-        .value()
+        .value
     }
 
     an[PatternReceiveError] should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""new x in { contract x(@{ y /\ ~Nil}) = { Nil } }""")
-        .value()
+        .value
     }
   }
 
@@ -726,7 +727,7 @@ class ProcMatcherSpec extends AnyFlatSpec with Matchers {
     noException should be thrownBy {
       Compiler[Eval]
         .sourceToADT("""new x in { contract x(@{ y /\ {Nil /\ Nil}}) = { Nil } }""")
-        .value()
+        .value
     }
   }
 
@@ -1422,7 +1423,7 @@ class ProcMatcherSpec extends AnyFlatSpec with Matchers {
            }
          }
        """
-        Compiler[Eval].sourceToADT(rho).value()
+        Compiler[Eval].sourceToADT(rho).value
         assert(true)
       } catch {
         case e: Throwable =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -1,8 +1,9 @@
 package coop.rchain.rholang.interpreter.matcher
 
+import cats.effect.Async.catsStateTAsync
 import cats.effect._
 import cats.mtl.implicits._
-import cats.{Eval => _}
+import cats.Eval
 import com.google.protobuf.ByteString
 import coop.rchain.catscontrib.MonadError_._
 import coop.rchain.models.Connective.ConnectiveInstance._
@@ -12,13 +13,13 @@ import coop.rchain.models.Var.WildcardMsg
 import coop.rchain.models._
 import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.rholang.interpreter._
-import monix.eval.{Eval, Task}
-import monix.execution.Scheduler.Implicits.global
+import monix.eval.Task
 import org.scalactic.TripleEqualsSupport
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent.TimeLimits
+import monix.execution.Scheduler.Implicits.global
 
 import scala.collection.immutable.BitSet
 import scala.concurrent.duration._
@@ -77,6 +78,7 @@ class VarMatcherSpec extends AnyFlatSpec with Matchers with TimeLimits with Trip
     expectedCaptures.map(_.map(c => (c._1, printer.buildString(c._2))))
 
   private def assertSorted(term: Par, termName: String): Assertion = {
+    import coop.rchain.catscontrib.effect.implicits.sEval
     val sortedTerm = Sortable[Par].sortMatch[Eval](term).value.term
     val clue       = s"Invalid test case - ${termName} is not sorted"
     assert(printer.buildString(term) == printer.buildString(sortedTerm), clue)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -12,7 +12,7 @@ import coop.rchain.models.Var.WildcardMsg
 import coop.rchain.models._
 import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.rholang.interpreter._
-import monix.eval.{Coeval, Task}
+import monix.eval.{Eval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
 import org.scalatest._
@@ -77,7 +77,7 @@ class VarMatcherSpec extends AnyFlatSpec with Matchers with TimeLimits with Trip
     expectedCaptures.map(_.map(c => (c._1, printer.buildString(c._2))))
 
   private def assertSorted(term: Par, termName: String): Assertion = {
-    val sortedTerm = Sortable[Par].sortMatch[Coeval](term).value.term
+    val sortedTerm = Sortable[Par].sortMatch[Eval](term).value.term
     val clue       = s"Invalid test case - ${termName} is not sorted"
     assert(printer.buildString(term) == printer.buildString(sortedTerm), clue)
     assert(term == sortedTerm, clue)

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
@@ -9,7 +9,7 @@ import coop.rchain.rholang.interpreter.RholangCLI
 import coop.rchain.rholang.interpreter.compiler.Compiler
 import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import coop.rchain.shared.Log
-import monix.eval.{Coeval, Task}
+import monix.eval.{Eval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.openjdk.jmh.annotations.{Setup, TearDown}
 
@@ -36,7 +36,7 @@ trait EvalBenchStateBase {
   def doSetup(): Unit = {
     deleteOldStorage(dbDir)
 
-    term = Compiler[Coeval].sourceToADT(resourceFileReader(rhoScriptSource)).runAttempt match {
+    term = Compiler[Eval].sourceToADT(resourceFileReader(rhoScriptSource)).runAttempt match {
       case Right(par) => Some(par)
       case Left(err)  => throw err
     }

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RhoBenchBaseState.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RhoBenchBaseState.scala
@@ -9,7 +9,7 @@ import coop.rchain.rholang.interpreter.compiler.Compiler
 import coop.rchain.rholang.interpreter.{ReplayRhoRuntime, RhoRuntime, RholangCLI}
 import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import coop.rchain.shared.Log
-import monix.eval.{Coeval, Task}
+import monix.eval.{Eval, Task}
 import monix.execution.Scheduler
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
@@ -61,13 +61,13 @@ abstract class RhoBenchBaseState {
   def doSetup(): Unit = {
     deleteOldStorage(dbDir)
     setupTerm = setupRho.flatMap { p =>
-      Compiler[Coeval].sourceToADT(p).runAttempt match {
+      Compiler[Eval].sourceToADT(p).runAttempt match {
         case Right(par) => Some(par)
         case Left(err)  => throw err
       }
     }
 
-    term = Compiler[Coeval].sourceToADT(testedRho).runAttempt match {
+    term = Compiler[Eval].sourceToADT(testedRho).runAttempt match {
       case Right(par) => par
       case Left(err)  => throw err
     }


### PR DESCRIPTION
## Overview
PR #1 in series of changes aiming to update to Cats Effects 3 and Scala 2.13.
Replace monix.Coeval with cats.Eval to achieve stack safety when working with Rholang types.


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
