### PR TITLE
Completely removed Monix. AtomicAny replaced with Ref

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -153,8 +153,7 @@ lazy val shared = (project in file("shared"))
       catsLawsTest,
       catsLawsTestkitTest,
       enumeratum,
-      jaxb,
-      monix // remove when monix TestSheduler is replaced
+      jaxb
     )
   )
   .dependsOn(sdk)
@@ -311,7 +310,6 @@ lazy val node = (project in file("node"))
         scalapbRuntimegGrpc,
         circeParser,
         circeGenericExtras,
-        monix, // remove when BatchInfluxDBReporter is adjusted to work w/o monix
         pureconfig
       ),
     scalacOptions ++= Seq(
@@ -511,8 +509,7 @@ lazy val rspace = (project in file("rspace"))
       catsCore,
       fs2Core,
       scodecCore,
-      scodecBits,
-      monix // remove when AtomicAny migrated to Ref
+      scodecBits
     ),
     /* Tutorial */
     /* Publishing Settings */

--- a/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeManager.scala
@@ -302,15 +302,17 @@ object RuntimeManager {
       )
       .flatMap {
         case (rSpacePlay, rSpaceReplay) =>
-          val historyRepo = rSpacePlay.historyRepo
-          RuntimeManager[F](
-            rSpacePlay,
-            rSpaceReplay,
-            historyRepo,
-            mergeableStore,
-            mergeableTagName,
-            executionTracker
-          ).map((_, historyRepo))
+          rSpacePlay.historyRepo.flatMap(
+            historyRepo =>
+              RuntimeManager[F](
+                rSpacePlay,
+                rSpaceReplay,
+                historyRepo,
+                mergeableStore,
+                mergeableTagName,
+                executionTracker
+              ).map((_, historyRepo))
+          )
       }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,6 @@ object Dependencies {
   val catsEffectVersion = "3.4.8"
   val catsMtlVersion    = "0.7.1"
   val fs2Version        = "3.6.1"
-  val monixVersion      = "3.4.0"
   val http4sVersion     = "0.23.6"
   val endpointsVersion  = "1.9.0"
   val circeVersion      = "0.14.3"
@@ -71,8 +70,6 @@ object Dependencies {
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.7.1"
   val magnolia            = "com.propensive"             %% "magnolia"                  % "0.17.0"
   val mockito             = "org.mockito"                %% "mockito-scala-cats"        % "1.17.14" % "test"
-  // TODO monix can be completely removed once AtomicAny in RSpace is replaced with Ref or AtomicCell from CE3
-  val monix               = "io.monix"                   %% "monix"                     % monixVersion
   val monixTesting        = "io.monix"                   %% "monix-testing-scalatest"   % "0.3.0"
   val ceTesting           = "org.typelevel"              %% "cats-effect-testing-scalatest"% "1.5.0" % Test
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"

--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -16,7 +16,6 @@ import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import coop.rchain.rspace.{Match, RSpace}
 import coop.rchain.shared.Log
 import coop.rchain.store.KeyValueStoreManager
-import monix.execution.Scheduler
 
 import java.io.File
 import java.nio.file.{Files, Path}
@@ -86,7 +85,8 @@ object Resources {
       runtimes <- RhoRuntime
                    .createRuntimes[F](space, replay, initRegistry, additionalSystemProcesses, Par())
       (runtime, replayRuntime) = runtimes
-    } yield (runtime, replayRuntime, space.historyRepo)
+      historyRepo              <- space.historyRepo
+    } yield (runtime, replayRuntime, historyRepo)
   }
 
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -90,7 +90,8 @@ class CostAccountingSpec
                            additionalSystemProcesses,
                            initRegistry
                          )
-    } yield (rhoRuntime, replayRhoRuntime, space.historyRepo)
+      historyRepo <- space.historyRepo
+    } yield (rhoRuntime, replayRhoRuntime, historyRepo)
   }
 
   def evaluateAndReplay(

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -13,14 +13,13 @@ import coop.rchain.rspace.internal.{ConsumeCandidate, Datum, ProduceCandidate, W
 import coop.rchain.rspace.trace._
 import coop.rchain.shared.{Log, Serialize}
 import coop.rchain.store.KeyValueStore
-import monix.execution.atomic.AtomicAny
 
 import scala.collection.SortedSet
 import scala.concurrent.ExecutionContext
 
 class RSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
     historyRepository: HistoryRepository[F, C, P, A, K],
-    storeAtom: AtomicAny[HotStore[F, C, P, A, K]]
+    storeRef: Ref[F, HotStore[F, C, P, A, K]]
 )(
     implicit
     serializeC: Serialize[C],
@@ -28,7 +27,7 @@ class RSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
     serializeA: Serialize[A],
     serializeK: Serialize[K],
     val m: Match[F, P, A]
-) extends RSpaceOps[F, C, P, A, K](historyRepository, storeAtom)
+) extends RSpaceOps[F, C, P, A, K](historyRepository, storeRef)
     with ISpace[F, C, P, A, K] {
 
   protected[this] override val logger: Logger = Logger[this.type]
@@ -81,7 +80,7 @@ class RSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
   private[this] def fetchChannelToIndexData(channels: Seq[C]): F[Map[C, Seq[(Datum[A], Int)]]] =
     channels
       .traverse { c: C =>
-        store.getData(c).shuffleWithIndex.map(c -> _)
+        store.flatMap(_.getData(c).shuffleWithIndex.map(c -> _))
       }
       .map(_.toMap)
 
@@ -94,7 +93,8 @@ class RSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
     Span[F].traceI("locked-produce") {
       for {
         //TODO fix double join fetch
-        groupedChannels <- store.getJoins(channel)
+        hotStore        <- store
+        groupedChannels <- hotStore.getJoins(channel)
         _ <- Log[F].debug(
               s"produce: searching for matching continuations at <groupedChannels: $groupedChannels>"
             )
@@ -118,10 +118,7 @@ class RSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
   ): F[MaybeProduceCandidate] =
     runMatcherForChannels(
       groupedChannels,
-      channels =>
-        store
-          .getContinuations(channels)
-          .shuffleWithIndex,
+      channels => store.flatMap(_.getContinuations(channels).shuffleWithIndex),
       /*
        * Here, we create a cache of the data at each channel as `channelToIndexedData`
        * which is used for finding matches.  When a speculative match is found, we can
@@ -134,8 +131,7 @@ class RSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
        */
       c =>
         store
-          .getData(c)
-          .shuffleWithIndex
+          .flatMap(_.getData(c).shuffleWithIndex)
           .map { d =>
             if (c == batChannel) (data, -1) +: d else d
           }
@@ -153,11 +149,12 @@ class RSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
     ) = pc
 
     for {
-      comm <- COMM(dataCandidates, consumeRef, peeks, produceCounters _)
-      _    <- logComm(dataCandidates, channels, wk, comm, produceCommLabel)
-      _    <- store.removeContinuation(channels, continuationIndex).unlessA(persistK)
-      _    <- removeMatchedDatumAndJoin(channels, dataCandidates)
-      _    <- Log[F].debug(s"produce: matching continuation found at <channels: $channels>")
+      comm     <- COMM(dataCandidates, consumeRef, peeks, produceCounters _)
+      _        <- logComm(dataCandidates, channels, wk, comm, produceCommLabel)
+      hotStore <- store
+      _        <- hotStore.removeContinuation(channels, continuationIndex).unlessA(persistK)
+      _        <- removeMatchedDatumAndJoin(channels, dataCandidates)
+      _        <- Log[F].debug(s"produce: matching continuation found at <channels: $channels>")
     } yield wrapResult(channels, wk, consumeRef, dataCandidates)
   }
 
@@ -195,11 +192,14 @@ class RSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
 
   override def createCheckpoint(): F[Checkpoint] = spanF.withMarks("create-checkpoint") {
     for {
-      changes <- spanF.withMarks("changes") { storeAtom.get().changes }
+      store       <- storeRef.get
+      changes     <- spanF.withMarks("changes") { store.changes }
+      historyRef  <- historyRepositoryRef
+      historyRepo <- historyRef.get
       nextHistory <- spanF.withMarks("history-checkpoint") {
-                      historyRepositoryAtom.get().checkpoint(changes.toList)
+                      historyRepo.checkpoint(changes.toList)
                     }
-      _             = historyRepositoryAtom.set(nextHistory)
+      _             <- historyRef.set(nextHistory)
       log           <- eventLog.getAndSet(Seq.empty)
       _             <- produceCounter.set(Map.empty.withDefaultValue(0))
       historyReader <- nextHistory.getHistoryReader(nextHistory.root)
@@ -210,7 +210,8 @@ class RSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
 
   def spawn: F[ISpace[F, C, P, A, K]] = spanF.withMarks("spawn") {
     for {
-      historyRepo   <- Sync[F].delay(historyRepositoryAtom.get())
+      historyRef    <- historyRepositoryRef
+      historyRepo   <- historyRef.get
       nextHistory   <- historyRepo.reset(historyRepo.history.root)
       historyReader <- nextHistory.getHistoryReader(nextHistory.root)
       hotStore      <- HotStore(historyReader.base)
@@ -245,7 +246,9 @@ object RSpace {
       sk: Serialize[K],
       m: Match[F, P, A]
   ): F[RSpace[F, C, P, A, K]] =
-    Sync[F].delay(new RSpace[F, C, P, A, K](historyRepository, AtomicAny(store)))
+    Ref
+      .of[F, HotStore[F, C, P, A, K]](store)
+      .map(storeRef => new RSpace[F, C, P, A, K](historyRepository, storeRef))
 
   /**
     * Creates [[RSpace]] from [[KeyValueStore]]'s,

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -227,10 +227,9 @@ class ReplayRSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
     for {
       store         <- storeRef.get
       changes       <- store.changes
-      historyRef    <- historyRepositoryRef
-      historyRepo   <- historyRef.get
+      historyRepo   <- historyRepositoryRef.get
       nextHistory   <- historyRepo.checkpoint(changes.toList)
-      _             <- historyRef.set(nextHistory)
+      _             <- historyRepositoryRef.set(nextHistory)
       historyReader <- nextHistory.getHistoryReader(nextHistory.root)
       _             <- createNewHotStore(historyReader)
       _             <- restoreInstalls()
@@ -294,8 +293,7 @@ class ReplayRSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
 
   def spawn: F[IReplaySpace[F, C, P, A, K]] = spanF.withMarks("spawn") {
     for {
-      historyRef    <- historyRepositoryRef
-      historyRepo   <- historyRef.get
+      historyRepo   <- historyRepositoryRef.get
       nextHistory   <- historyRepo.reset(historyRepo.history.root)
       historyReader <- nextHistory.getHistoryReader(nextHistory.root)
       hotStore      <- HotStore(historyReader.base)

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -4,7 +4,6 @@ import cats.effect._
 import cats.syntax.all._
 import com.google.common.collect.Multiset
 import com.typesafe.scalalogging.Logger
-import coop.rchain.catscontrib._
 import coop.rchain.metrics.implicits._
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.rspace.history.HistoryRepository
@@ -12,15 +11,13 @@ import coop.rchain.rspace.internal._
 import coop.rchain.rspace.trace._
 import coop.rchain.shared.syntax._
 import coop.rchain.shared.{Log, Serialize}
-import monix.execution.atomic.AtomicAny
 
 import scala.collection.SortedSet
-import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class ReplayRSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
     historyRepository: HistoryRepository[F, C, P, A, K],
-    storeAtom: AtomicAny[HotStore[F, C, P, A, K]]
+    storeRef: Ref[F, HotStore[F, C, P, A, K]]
 )(
     implicit
     serializeC: Serialize[C],
@@ -28,7 +25,7 @@ class ReplayRSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
     serializeA: Serialize[A],
     serializeK: Serialize[K],
     val m: Match[F, P, A]
-) extends RSpaceOps[F, C, P, A, K](historyRepository, storeAtom)
+) extends RSpaceOps[F, C, P, A, K](historyRepository, storeRef)
     with IReplaySpace[F, C, P, A, K] {
 
   protected override def logF: Log[F] = Log[F]
@@ -95,7 +92,7 @@ class ReplayRSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
     for {
       channelToIndexedDataList <- channels.traverse { c: C =>
                                    store
-                                     .getData(c)
+                                     .flatMap(_.getData(c))
                                      .flatMap(
                                        _.iterator.zipWithIndex.to(Seq).filterA(matches(comm))
                                      )
@@ -113,7 +110,8 @@ class ReplayRSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
   ): F[MaybeActionResult] =
     Span[F].traceI("locked-produce") {
       for {
-        groupedChannels <- store.getJoins(channel)
+        hotStore        <- store
+        groupedChannels <- hotStore.getJoins(channel)
         _ <- logF.debug(
               s"produce: searching for matching continuations at <groupedChannels: $groupedChannels>"
             )
@@ -163,14 +161,14 @@ class ReplayRSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
       groupedChannels,
       channels =>
         store
-          .getContinuations(channels)
+          .flatMap(_.getContinuations(channels))
           .map(_.iterator.zipWithIndex.filter {
             case (WaitingContinuation(_, _, _, _, source), _) =>
               comm.consume == source
           }.toSeq),
       c =>
         store
-          .getData(c)
+          .flatMap(_.getData(c))
           .map(_.iterator.zipWithIndex.to(Seq))
           .flatMap { datums =>
             (if (c == channel) (Datum(data, persist, produceRef), -1) +: datums else datums)
@@ -207,10 +205,11 @@ class ReplayRSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
             comms.contains(commRef),
             s"COMM Event $commRef was not contained in the trace $comms"
           )
-      _ <- store.removeContinuation(channels, continuationIndex).unlessA(persistK)
-      _ <- removeMatchedDatumAndJoin(channels, dataCandidates)
-      _ <- logF.debug(s"produce: matching continuation found at <channels: $channels>")
-      _ <- removeBindingsFor(commRef)
+      hotStore <- store
+      _        <- hotStore.removeContinuation(channels, continuationIndex).unlessA(persistK)
+      _        <- removeMatchedDatumAndJoin(channels, dataCandidates)
+      _        <- logF.debug(s"produce: matching continuation found at <channels: $channels>")
+      _        <- removeBindingsFor(commRef)
     } yield wrapResult(channels, wk, consumeRef, dataCandidates)
   }
 
@@ -226,9 +225,12 @@ class ReplayRSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
 
   override def createCheckpoint(): F[Checkpoint] = checkReplayData() >> syncF.defer {
     for {
-      changes       <- storeAtom.get().changes
-      nextHistory   <- historyRepositoryAtom.get().checkpoint(changes.toList)
-      _             = historyRepositoryAtom.set(nextHistory)
+      store         <- storeRef.get
+      changes       <- store.changes
+      historyRef    <- historyRepositoryRef
+      historyRepo   <- historyRef.get
+      nextHistory   <- historyRepo.checkpoint(changes.toList)
+      _             <- historyRef.set(nextHistory)
       historyReader <- nextHistory.getHistoryReader(nextHistory.root)
       _             <- createNewHotStore(historyReader)
       _             <- restoreInstalls()
@@ -292,7 +294,8 @@ class ReplayRSpace[F[_]: Async: Log: Metrics: Span, C, P, A, K](
 
   def spawn: F[IReplaySpace[F, C, P, A, K]] = spanF.withMarks("spawn") {
     for {
-      historyRepo   <- Sync[F].delay(historyRepositoryAtom.get())
+      historyRef    <- historyRepositoryRef
+      historyRepo   <- historyRef.get
       nextHistory   <- historyRepo.reset(historyRepo.history.root)
       historyReader <- nextHistory.getHistoryReader(nextHistory.root)
       hotStore      <- HotStore(historyReader.base)
@@ -317,8 +320,9 @@ object ReplayRSpace {
       sa: Serialize[A],
       sk: Serialize[K],
       m: Match[F, P, A]
-  ): F[ReplayRSpace[F, C, P, A, K]] = Sync[F].delay {
-    new ReplayRSpace[F, C, P, A, K](historyRepository, AtomicAny(store))
-  }
+  ): F[ReplayRSpace[F, C, P, A, K]] =
+    Ref
+      .of[F, HotStore[F, C, P, A, K]](store)
+      .map(storeRef => new ReplayRSpace[F, C, P, A, K](historyRepository, storeRef))
 
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/ExportImportTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ExportImportTests.scala
@@ -13,7 +13,6 @@ import coop.rchain.rspace.state.{RSpaceExporter, RSpaceImporter}
 import coop.rchain.shared.ByteVectorOps.RichByteVector
 import coop.rchain.shared.{Log, Serialize}
 import coop.rchain.store.InMemoryStoreManager
-import monix.execution.atomic.AtomicAny
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scodec.bits.ByteVector
@@ -282,7 +281,7 @@ trait InMemoryExportImportTestsBase[C, P, A, K] {
       historyReader <- historyRepository1.getHistoryReader(historyRepository1.root)
       store1 <- {
         val hr = historyReader.base
-        HotStore[IO, C, P, A, K](cache1, hr).map(AtomicAny(_))
+        HotStore[IO, C, P, A, K](cache1, hr).flatMap(Ref.of[IO, HotStore[IO, C, P, A, K]](_))
       }
       space1 = new RSpace[IO, C, P, A, K](
         historyRepository1,
@@ -303,7 +302,7 @@ trait InMemoryExportImportTestsBase[C, P, A, K] {
       historyReader <- historyRepository2.getHistoryReader(historyRepository2.root)
       store2 <- {
         val hr = historyReader.base
-        HotStore[IO, C, P, A, K](cache2, hr).map(AtomicAny(_))
+        HotStore[IO, C, P, A, K](cache2, hr).flatMap(Ref.of[IO, HotStore[IO, C, P, A, K]](_))
       }
       space2 = new RSpace[IO, C, P, A, K](
         historyRepository2,

--- a/rspace/src/test/scala/coop/rchain/rspace/test/package.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/package.scala
@@ -21,7 +21,7 @@ package object test {
   }
 
   implicit class StoreOps[F[_]: Functor, C, P, A, K](val store: HotStore[F, C, P, A, K]) {
-    def isEmpty(): F[Boolean] =
+    def isEmpty: F[Boolean] =
       store.changes.map(collectActions[InsertAction]).map(_.isEmpty)
   }
 }


### PR DESCRIPTION
## Overview

[Monix](https://monix.io/) has been completely removed from the project. `AtomicAny` from Monix replaced with `Ref` from cats-effect.
Added compiler options for successfully building a project from Intellij IDEA and debugging tests.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
